### PR TITLE
Add config option: dest.outputFilename. Update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ export default {
 
     -   `fontsDir` - (required) directory fonts saving.
     -   `stylesDir` - (optional) directory styles saving.
+    -   `outputFilename` - (optional) Set the filename of the generated styles file
 
 ## Related
 

--- a/src/WebfontPlugin.js
+++ b/src/WebfontPlugin.js
@@ -55,6 +55,8 @@ export default class WebfontPlugin {
                             `${result.config.fontName}.${result.config
                                 .template}`
                         );
+                    } else if (this.options.dest.outputFilename) {
+                        destStyles = path.join(destStyles, this.options.dest.outputFilename);
                     } else {
                         destStyles = path.join(
                             destStyles,

--- a/src/WebfontPlugin.js
+++ b/src/WebfontPlugin.js
@@ -56,7 +56,10 @@ export default class WebfontPlugin {
                                 .template}`
                         );
                     } else if (this.options.dest.outputFilename) {
-                        destStyles = path.join(destStyles, this.options.dest.outputFilename);
+                        destStyles = path.join(
+                            destStyles,
+                            this.options.dest.outputFilename
+                        );
                     } else {
                         destStyles = path.join(
                             destStyles,


### PR DESCRIPTION
Presently when using custom templates, the template's filename is used as the destination styles filename rather than the font name. This seems counter-intuitive, so this adds the ability to set the filename explicitly to override that.

Longer term it might be better to have the non-custom and custom template versions output the same filename, as I feel that would be more intuitive.