### PR TITLE
PR for issue #77 - Infinite recompilation fixes. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,11 @@
         "!**/__tests__"
     ],
     "dependencies": {
-        "webfont": "^7.0.0",
         "fs-extra": "^4.0.0",
+        "glob": "^7.1.2",
+        "glob-parent": "^3.1.0",
         "nodeify": "^1.0.0",
-        "glob-parent": "^3.1.0"
+        "webfont": "^7.0.0"
     },
     "devDependencies": {
         "ava": "^0.21.0",


### PR DESCRIPTION
Fix for issue #77 

This PR adds checking against:

1) The destination filename for generated CSS/SCSS files
2) Changed source font files. This seems to eliminate the infinite recompilation issue.

You'll notice a new handler added for the watcher's `invalid` hook, which catches file changes. If the above conditions are met, the `skip` flag is set accordingly. I'm not sure of a better way to do this because of the timings of hooks; `invalid` fires much earlier than anything else which makes this more reliable than trying to discern file changes at `emit` time. Let me know if you think this is off-base.

Also, this may or may not provide the solution needed to wrapping up issue #7 

I might recommend bumping the minor version number for this fix as it is substantial if it eliminates infinite compilation loops.